### PR TITLE
Improve report graphs and add export options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,7 @@ Aplicación de monitoreo y reportes de producción.
 Instalar las librerías necesarias:
 
 ```bash
-pip install customtkinter pillow tkcalendar matplotlib plotly kaleido
+pip install customtkinter pillow tkcalendar matplotlib plotly kaleido pandas fpdf openpyxl
 ```
+
+La vista de reportes permite exportar los datos a PDF o Excel, incluyendo tiempos de paro y métricas diarias.


### PR DESCRIPTION
## Summary
- Capture downtime minutes in report summaries
- Render report charts at higher resolution and offer export to PDF or Excel
- Document new dependencies and export capability

## Testing
- `pip install pandas fpdf openpyxl`
- `python -m py_compile mefrupALS.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3dea3a9a08328b6f2c5e7be5eb889