### PR TITLE
feat: add ALS-style OEE reporting helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,14 @@ pip install customtkinter pillow tkcalendar matplotlib plotly kaleido pandas fpd
 ```
 
 La vista de reportes permite exportar los datos a PDF o Excel, incluyendo tiempos de paro y métricas diarias.
+
+### Módulo de reportes
+
+`mefrupALS.py` expone funciones de visualización con Plotly:
+
+- `plot_turnos(df)`: barras A/P/Q y línea OEE por turno o día.
+- `panel_kpis(df)`: resumen horizontal de KPIs del periodo.
+- `kpi_card(df)`: tarjeta con métricas agregadas y estadísticas.
+- `heatmap_oee(df)`: mapa de calor OEE día vs turno.
+
+Cada una recibe un `DataFrame` filtrado por máquina y rango de fechas y devuelve `plotly.graph_objects.Figure` listo para integrar.


### PR DESCRIPTION
## Summary
- add Plotly helpers for turn/ daily OEE bars with line
- provide KPI panels and metric tables for ranges
- document new reporting utilities

## Testing
- `python -m py_compile MEFRUP-MLS/mefrupALS.py`

------
https://chatgpt.com/codex/tasks/task_e_68a4156a84648328ba16c120b0eb5439