### PR TITLE
Add machine recipes panel placeholder

### DIFF
--- a/mefrupALS.py
+++ b/mefrupALS.py
@@ -14,6 +14,7 @@ from csv_utils import *
 from metrics import *
 
 from views.recipes import RecipesView
+from views.machine_recipes import MachineRecipesView
 from views.machine_chooser import MachineChooser
 from views.oee_view import OEEView
 from views.live_dashboard import LiveDashboard
@@ -96,6 +97,7 @@ class App(ctk.CTk):
         self.container=ctk.CTkFrame(self, corner_radius=0, fg_color="transparent"); self.container.pack(fill="both", expand=True)
         self.menu_page=MainMenu(self.container, self)
         self.recipes_page=RecipesView(self.container, self)
+        self.machine_recipes_page=MachineRecipesView(self.container, self)
         self.choose_page=MachineChooser(self.container, self)
         self.dashboard_page=LiveDashboard(self.container, self)
         self.reports_page=ReportsView(self.container, self)
@@ -158,6 +160,10 @@ class App(ctk.CTk):
     def go_recipes(self):
         self._unbind_shortcuts_oee()
         self._pack_only(self.recipes_page)
+
+    def go_machine_recipes(self):
+        self._unbind_shortcuts_oee()
+        self._pack_only(self.machine_recipes_page)
 
     def go_planning(self):
         if not self.planning_page:

--- a/views/machine_recipes.py
+++ b/views/machine_recipes.py
@@ -1,0 +1,27 @@
+from .base import *
+
+class MachineRecipesView(ctk.CTkFrame):
+    """Panel vacío para gestionar recetas por máquina."""
+    def __init__(self, master, app):
+        super().__init__(master, fg_color="transparent")
+        self.app = app
+        self._build()
+
+    def _build(self):
+        header = ctk.CTkFrame(self, corner_radius=0, fg_color=("white", "#0e1117"))
+        header.pack(fill="x", side="top")
+        left = ctk.CTkFrame(header, fg_color="transparent")
+        left.pack(side="left", padx=16, pady=12)
+        ctk.CTkButton(
+            left, text="← Menú", command=self.app.go_menu, width=110, corner_radius=10,
+            fg_color="#E5E7EB", text_color="#111", hover_color="#D1D5DB"
+        ).pack(side="left", padx=(0, 10))
+        title_box = ctk.CTkFrame(left, fg_color="transparent")
+        title_box.pack(side="left")
+        ctk.CTkLabel(title_box, text="Machine Recipes", font=ctk.CTkFont("Helvetica", 22, "bold")).pack(anchor="w")
+        ctk.CTkLabel(
+            title_box, text="En construcción", text_color=("#6b7280", "#9CA3AF"), font=ctk.CTkFont(size=12)
+        ).pack(anchor="w")
+
+        body = ctk.CTkFrame(self, fg_color="transparent")
+        body.pack(fill="both", expand=True)

--- a/views/main_menu.py
+++ b/views/main_menu.py
@@ -30,6 +30,8 @@ class MainMenu(ctk.CTkFrame):
             {"text": "OEE y Registro de Producción", "command": app.go_oee_select_machine, "height": 48},
             {"text": "Recetas (Moldes/Partes)", "command": app.go_recipes, "height": 44,
              "fg_color": "#E5E7EB", "text_color": "#111", "hover_color": "#D1D5DB"},
+            {"text": "Recetas por Máquina", "command": app.go_machine_recipes, "height": 44,
+             "fg_color": "#E5E7EB", "text_color": "#111", "hover_color": "#D1D5DB"},
             {"text": "Planificación + Milestones", "command": app.go_planning, "height": 44},
             {"text": "Tablero de Órdenes (Progreso)", "command": app.go_orders_board, "height": 44},
             {"text": "Reportes de Producción", "command": app.go_reports, "height": 44},


### PR DESCRIPTION
## Summary
- add Machine Recipes view as placeholder panel
- expose Machine Recipes from main menu
- wire machine recipes navigation in app

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a7b103d95c8328b37c4828cd9ae6ad