### PR TITLE
Avoid zeros for blank Excel cells

### DIFF
--- a/views/machine_recipes.py
+++ b/views/machine_recipes.py
@@ -334,7 +334,7 @@ def _anchor_address(ws, addr: str) -> str:
 
 def _to_excel_value(excel_key: str, ui_key: str, raw_val):
     s = "" if raw_val is None else str(raw_val).strip()
-    if s == "":
+    if s == "" or s.replace("0", "").replace(".", "") == "":
         return None
     keys = {excel_key, ui_key}
     if any(k in NUM_FIELDS for k in keys):


### PR DESCRIPTION
## Summary
- Treat zero-like values as blank when exporting machine recipe snapshots to Excel

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae87c2493083289d7de548903c6f2a