### PR TITLE
fix: remove external links and drawings when exporting

### DIFF
--- a/views/machine_recipes.py
+++ b/views/machine_recipes.py
@@ -376,6 +376,15 @@ def _to_excel_value(excel_key: str, ui_key: str, raw_val):
             pass
     return _safe_excel(s)
 
+
+def _strip_external_links_and_drawings(wb):
+    """Remove external links and drawings to avoid Excel repair prompts."""
+    if getattr(wb, "_external_links", None):
+        wb._external_links = []
+    for ws in wb.worksheets:
+        ws._rels = [r for r in ws._rels if "drawing" not in getattr(r, "Type", "")]
+        ws._drawing = None
+
 def _export_snapshot_to_template(snapshot: dict, out_path: str, template_path: str, sheet_name: str | None = None):
     """
     Abre la plantilla y escribe los valores según EXCEL_MAP en la hoja indicada (o activa).
@@ -398,6 +407,7 @@ def _export_snapshot_to_template(snapshot: dict, out_path: str, template_path: s
         target = _anchor_address(ws, spec)        # resuelve merges y "COLS:ROW"
         ws[target].value = _to_excel_value(excel_key, ui_key, val)
 
+    _strip_external_links_and_drawings(wb)
     wb.save(out_path)
 
 def _a1_from_spec(spec: str) -> str:


### PR DESCRIPTION
## Summary
- remove external links and drawing references when exporting machine recipes

## Testing
- `python -m py_compile views/machine_recipes.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae9046f7708328a43d4fd7e57c3441