### PR TITLE
docs: list missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Aplicación de monitoreo y reportes de producción.
 Instalar las librerías necesarias:
 
 ```bash
-pip install customtkinter pillow tkcalendar matplotlib plotly kaleido pandas fpdf openpyxl
+pip install \
+  customtkinter pillow tkcalendar matplotlib plotly kaleido pandas numpy seaborn fpdf openpyxl pywin32 python-dotenv openai
 ```
 
 La vista de reportes permite exportar los datos a PDF o Excel, incluyendo tiempos de paro y métricas diarias.


### PR DESCRIPTION
## Summary
- list extra dependencies like numpy, seaborn, pywin32, python-dotenv and openai in README install command

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aea0e604c48328b46096a5ef880114