### PR TITLE
Fix missing imports for machine recipe panels

### DIFF
--- a/views/machine_recipes_history_panel.py
+++ b/views/machine_recipes_history_panel.py
@@ -1,6 +1,13 @@
 # -*- coding: utf-8 -*-
 from .base import *  # ctk, tk, ttk, messagebox, filedialog
 from .machine_recipes_constants import *
+from .machine_recipes_constants import (
+    _versions_dir,
+    _list_versions,
+    _load_json,
+    _save_version_snapshot,
+    _load_version_snapshot,
+)
 import json, os, sys
 
 def open_history(view):

--- a/views/machine_recipes_panel.py
+++ b/views/machine_recipes_panel.py
@@ -3,6 +3,11 @@ from .base import *  # ctk, tk, ttk, messagebox, filedialog, BASE_DIR
 import os, json, csv, sys, re
 from datetime import datetime
 from .machine_recipes_constants import *
+from .machine_recipes_constants import (
+    _load_json,
+    _save_json,
+    _save_version_snapshot,
+)
 from .machine_recipes_history_panel import open_history
 
 class MachineRecipesView(ctk.CTkFrame):


### PR DESCRIPTION
## Summary
- import hidden helpers from `machine_recipes_constants` in the modularized panels

## Testing
- `python -m py_compile views/machine_recipes_panel.py views/machine_recipes_history_panel.py`

------
https://chatgpt.com/codex/tasks/task_e_68aea39457588328896077339545bd1a