### PR TITLE
Fix Excel template lookup for history export

### DIFF
--- a/views/machine_recipes_history_panel.py
+++ b/views/machine_recipes_history_panel.py
@@ -7,6 +7,7 @@ from .machine_recipes_constants import (
     _load_json,
     _save_version_snapshot,
     _load_version_snapshot,
+    _find_excel_template,
 )
 import json, os, sys
 


### PR DESCRIPTION
## Summary
- import `_find_excel_template` in history panel to resolve Excel export error

## Testing
- `python -m compileall views/machine_recipes_history_panel.py`


------
https://chatgpt.com/codex/tasks/task_e_68aea528bf9083289ce40b1f12060d1b