### PR TITLE
Fix missing _cast_numeric import in machine recipes panel

### DIFF
--- a/views/machine_recipes_panel.py
+++ b/views/machine_recipes_panel.py
@@ -7,6 +7,7 @@ from .machine_recipes_constants import (
     _load_json,
     _save_json,
     _save_version_snapshot,
+    _cast_numeric,
 )
 from .machine_recipes_history_panel import open_history
 


### PR DESCRIPTION
## Summary
- import helper `_cast_numeric` into `machine_recipes_panel` to avoid NameError when saving or importing values

## Testing
- `python -m py_compile views/machine_recipes_panel.py`


------
https://chatgpt.com/codex/tasks/task_e_68aea7f5910083289a4755a083786276